### PR TITLE
Removed Travis-CI badge, redirected godoc badge.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # vt10x
 
-[![Build Status](https://travis-ci.org/hinshun/vt10x.svg?branch=master)](https://travis-ci.org/hinshun/vt10x)
-[![GoDoc](https://godoc.org/github.com/hinshun/vt10x?status.svg)](https://godoc.org/github.com/hinshun/vt10x)
+[![GoDoc](https://godoc.org/github.com/ActiveState/vt10x?status.svg)](https://godoc.org/github.com/ActiveState/vt10x)
 
 Package vt10x is a vt10x terminal emulation backend, influenced
 largely by st, rxvt, xterm, and iTerm as reference. Use it for terminal


### PR DESCRIPTION
Tiniest little update to remove the hinshun travis-ci badge, and to change the link on the godoc badge to this repo's documentation.